### PR TITLE
Force c++17 for new Qt's, but c++11 for older compilers and Qt's

### DIFF
--- a/build/common.prf
+++ b/build/common.prf
@@ -39,7 +39,7 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
 	error(Unsupported Qt version for PythonQt: missing generated_cpp)
 }
 
-greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 9): CONFIG += c++latest c++11
+greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 9): CONFIG += c++17 c++11
 win32: CONFIG += skip_target_version_ext
 gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -ansi -pedantic
 win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-unused-command-line-argument

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,7 +2,7 @@ DEFINES +=  PYTHONQT_EXPORTS
 
 INCLUDEPATH += $$PWD
 
-CONFIG += c++11 c++latest
+CONFIG += c++11 c+17
 
 gcc:!no_warn:!clang:QMAKE_CXXFLAGS += -Wno-error=missing-field-initializers
 *-clang*:!no_warn:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized


### PR DESCRIPTION
For example, in AltLinux GCC does not know about -std=c++2b
